### PR TITLE
Aliases (issue 21)

### DIFF
--- a/lib/apikey.rb
+++ b/lib/apikey.rb
@@ -15,6 +15,7 @@ module CivoCLI
       end
       puts Terminal::Table.new headings: ['Name', 'Key', 'Default?'], rows: rows
     end
+    map "ls" => "list", "all" => "list"
 
     desc "add NAME KEY", "Add the API Key 'KEY' using a label of 'NAME'"
     def add(name, key)
@@ -52,6 +53,6 @@ module CivoCLI
     end
     map "use" => "current"
 
-    default_task :list
+    default_task :help
   end
 end

--- a/lib/blueprint.rb
+++ b/lib/blueprint.rb
@@ -15,6 +15,7 @@ module CivoCLI
       puts e.result.reason.colorize(:red)
       exit 1
     end
+    map "ls" => "list", "all" => "list"
 
     desc "show ID", "show the details for a single blueprint"
     option :verbose, type: :boolean, desc: "Show the converted bash script and last run output", aliases: ["-v"]
@@ -129,5 +130,6 @@ module CivoCLI
         result[0]
       end
     end
+    default_task :help
   end
 end

--- a/lib/blueprint.rb
+++ b/lib/blueprint.rb
@@ -50,6 +50,7 @@ module CivoCLI
       puts e.result.reason.colorize(:red)
       exit 1
     end
+    map "get" => "show", "inspect" => "show"
 
     option "content-file", type: :string, desc: "The filename of a file to be used as the Blueprintfile content", aliases: ["-c"], banner: "CONTENT_FILE"
     option "template-id", type: :string, desc: "The ID of the template to update", aliases: ["-t"], banner: "TEMPLATE_ID"

--- a/lib/domain.rb
+++ b/lib/domain.rb
@@ -9,6 +9,8 @@ module CivoCLI
       end
       puts Terminal::Table.new headings: ['ID', 'Name'], rows: rows
     end
+    map "ls" => "list", "all" => "list"
+
 
     desc "create DOMAIN", "create a new domain name called DOMAIN"
     def create(name)
@@ -33,7 +35,7 @@ module CivoCLI
     end
     map "delete" => "remove", "rm" => "remove"
 
-    default_task :list
+    default_task :help
 
   end
 end

--- a/lib/domain_record.rb
+++ b/lib/domain_record.rb
@@ -13,6 +13,8 @@ module CivoCLI
       end
       puts Terminal::Table.new headings: ['ID', 'Type', 'Name', 'Value', 'TTL', 'Priority'], rows: rows
     end
+    map "ls" => "list", "all" => "list"
+
 
     desc "show RECORD_ID", "show full information for record RECORD_ID (or full DNS name)"
     def show(record_id)
@@ -95,7 +97,7 @@ module CivoCLI
     end
     map "delete" => "remove", "rm" => "remove"
 
-    default_task :list
+    default_task :help
 
     private
 

--- a/lib/domain_record.rb
+++ b/lib/domain_record.rb
@@ -36,6 +36,7 @@ module CivoCLI
       puts e.result.reason.colorize(:red)
       exit 1
     end
+    map "get" => "show", "inspect" => "show"
 
     option :priority, type: :string, desc: "The priority for MX records", aliases: ["-p"], banner: "PRIORITY"
     option :ttl, type: :string, desc: "The Time-To-Live for this record", aliases: ["-t"], banner: "TTL"

--- a/lib/firewall.rb
+++ b/lib/firewall.rb
@@ -23,6 +23,7 @@ module CivoCLI
       puts e.result.reason.colorize(:red)
       exit 1
     end
+    map "ls" => "list", "all" => "list"
 
     desc "remove firewall_ID", "Removes a firewall with Firewall ID provided"
     def remove(firewall_ID)
@@ -81,5 +82,6 @@ module CivoCLI
       puts e.result.reason.colorize(:red)
       exit 1
     end
+   default_task :help
   end
 end

--- a/lib/instance.rb
+++ b/lib/instance.rb
@@ -11,6 +11,8 @@ module CivoCLI
       end
       puts Terminal::Table.new headings: ['ID', 'Hostname', 'Size', 'Region', 'Public IP', 'Status'], rows: rows
     end
+    map "ls" => "list", "all" => "list"
+
 
     if CivoCLI::Config.get_meta("admin")
       desc "high-cpu", "list high CPU using instances"
@@ -322,7 +324,7 @@ module CivoCLI
       exit 1  
     end
   
-    default_task :list
+    default_task :help
 
     private
 

--- a/lib/instance.rb
+++ b/lib/instance.rb
@@ -78,6 +78,7 @@ module CivoCLI
       puts e.result.reason.colorize(:red)
       exit 1
     end
+    map "get" => "show", "inspect" => "show"
 
     desc "create [HOSTNAME] [...]", "create a new instance with specified hostname and provided options"
     option :size, default: 'g2.small', banner: 'instance_size_code'

--- a/lib/kubernetes.rb
+++ b/lib/kubernetes.rb
@@ -11,6 +11,8 @@ module CivoCLI
     rescue Flexirest::HTTPForbiddenClientException
       reject_user_access
     end
+    map "ls" => "list", "all" => "list"
+
 
     desc "show ID/NAME", "show a Kubernetes cluster by ID or name"
     def show(id)
@@ -139,9 +141,9 @@ module CivoCLI
       puts e.result.reason.colorize(:red)
       exit 1
     end
-    map "delete" => "remove", "destroy" => "remove"
+    map "delete" => "remove", "destroy" => "remove", "rm" => "remove"
 
-    default_task :list
+    default_task :help
 
     private
 

--- a/lib/kubernetes.rb
+++ b/lib/kubernetes.rb
@@ -45,6 +45,8 @@ module CivoCLI
       puts e.result.reason.colorize(:red)
       exit 1
     end
+    map "get" => "show", "inspect" => "show"
+
 
     desc "config ID/NAME", "get the ~/.kube/config for a Kubernetes cluster by ID or name"
     def config(id)

--- a/lib/network.rb
+++ b/lib/network.rb
@@ -13,6 +13,8 @@ module CivoCLI
       end
       puts Terminal::Table.new headings: ['ID', 'Label', 'CIDR', 'Default?'], rows: rows
     end
+    map "ls" => "list", "all" => "list"
+
 
     desc "create LABEL", "create a new private network called LABEL"
     def create(label)
@@ -37,7 +39,7 @@ module CivoCLI
     end
     map "delete" => "remove", "rm" => "remove"
 
-    default_task :list
+    default_task :help
 
   end
 end

--- a/lib/region.rb
+++ b/lib/region.rb
@@ -9,6 +9,8 @@ module CivoCLI
       end
       puts Terminal::Table.new headings: ['Code'], rows: rows
     end
+    map "ls" => "list", "all" => "list"
+
 
     default_task :list
   end

--- a/lib/snapshot.rb
+++ b/lib/snapshot.rb
@@ -9,6 +9,8 @@ module CivoCLI
       end
       puts Terminal::Table.new headings: ['ID', 'Name', 'State', "Size (GB)", "Cron"], rows: rows
     end
+    map "ls" => "list", "all" => "list"
+
 
     option "cron", type: :string, desc: "The timing of when to take/repeat in cron format", aliases: ["-c"], banner: "CRON_TIMING"
     desc "create NAME INSTANCE_ID [-c '0 * * * *']", "create a snapshot called NAME from instance INSTANCE_ID"
@@ -37,7 +39,7 @@ module CivoCLI
     end
     map "delete" => "remove", "rm" => "remove"
 
-    default_task :list
+    default_task :help
 
   end
 end

--- a/lib/sshkey.rb
+++ b/lib/sshkey.rb
@@ -9,6 +9,8 @@ module CivoCLI
       end
       puts Terminal::Table.new headings: ['ID', 'Name', 'Fingerprint'], rows: rows
     end
+    map "ls" => "list", "all" => "list"
+
 
     desc "upload NAME FILENAME", "upload the SSH public key in FILENAME to a new key called NAME"
     def upload(name, filename)
@@ -33,6 +35,6 @@ module CivoCLI
     end
     map "delete" => "remove", "rm" => "remove"
 
-    default_task :list
+    default_task :help
   end
 end

--- a/lib/template.rb
+++ b/lib/template.rb
@@ -17,7 +17,6 @@ module CivoCLI
           rows << [template.id, template.name]
         end
         puts Terminal::Table.new headings: ['ID', 'Name'], rows: rows
-   
       end
 
     
@@ -25,8 +24,7 @@ module CivoCLI
       puts e.result.reason.colorize(:red)
       exit 1
     end
-    map "ls" => "list"
-
+    map "ls" => "list", "all" => "list"
 
     desc "show ID", "show the details for a single template"
     def show(id)
@@ -106,6 +104,6 @@ module CivoCLI
     end
     map "delete" => "remove", "rm" => "remove"
 
-    default_task :list
+    default_task :help
   end
 end

--- a/lib/template.rb
+++ b/lib/template.rb
@@ -45,6 +45,8 @@ module CivoCLI
       puts e.result.reason.colorize(:red)
       exit 1
     end
+    map "get" => "show", "inspect" => "show"
+
 
     option "cloud-init-file", type: :string, desc: "The filename of a file to be used as user-data/cloud-init", aliases: ["-c"], banner: "CLOUD_INIT_FILENAME"
     option :description, type: :string, desc: "A full/long multiline description", aliases: ["-d"], banner: "DESCRIPTION"

--- a/lib/volume.rb
+++ b/lib/volume.rb
@@ -10,6 +10,7 @@ module CivoCLI
       end
       puts Terminal::Table.new headings: ['ID', 'Name', 'Mounted', 'Size (GB)'], rows: rows
     end
+    map "ls" => "list", "all" => "list"
 
     desc "create NAME SIZE", "create a volume of SIZE (GB) called NAME"
     def create(name, size)
@@ -83,6 +84,6 @@ module CivoCLI
       exit 1
     end
 
-    default_task :list
+    default_task :help
   end
 end


### PR DESCRIPTION
Aliases `get` and `inspect` for `show` in methods where this is an option.
Aliases `ls` and `all` for `list` where this is an option.
Makes `help` the default method if the method is called with no specifics and it has multiple options (not for quota or sizes, essentially).

Closes #21