### PR TITLE
Hostname fix

### DIFF
--- a/lib/instance.rb
+++ b/lib/instance.rb
@@ -86,6 +86,7 @@ module CivoCLI
     DEFAULT_INITIAL_USER = 'civo'
     DEFAULT_PUBLIC_IP = 'true'
     DEFAULT_TEMPLATE = '811a8dfb-8202-49ad-b1ef-1e6320b20497'
+    option :name, aliases: '--hostname', banner: 'hostname'
     option :size, default: DEFAULT_SIZE, banner: 'instance_size_code'
     option :region, default: DEFAULT_REGION, banner: 'civo_region'
     option :public_ip, default: DEFAULT_PUBLIC_IP, banner: 'true | false | from [instance_id]'
@@ -95,7 +96,6 @@ module CivoCLI
     option :ssh_key, banner: 'ssh_key_id', aliases: '--ssh'
     option :tags, banner: "'tag1 tag2 tag3...'"
     option :wait, type: :boolean
-    option :name, aliases: '--hostname', banner: 'hostname'
     long_desc <<-LONGDESC
       Create a new instance with hostname (randomly assigned if blank), instance size (default: g2.small),
       \x5template or snapshot ID (default: Ubuntu 18.04 template).

--- a/lib/instance.rb
+++ b/lib/instance.rb
@@ -81,10 +81,15 @@ module CivoCLI
     map "get" => "show", "inspect" => "show"
 
     desc "create [HOSTNAME] [...]", "create a new instance with specified hostname and provided options"
-    option :size, default: 'g2.small', banner: 'instance_size_code'
-    option :region, default: 'lon1', banner: 'civo_region'
-    option :public_ip, default: 'true', banner: 'true | false | from [instance_id]'
-    option :initial_user, default: 'civo', banner: 'username', aliases: '--user'
+    DEFAULT_SIZE = 'g2.small'
+    DEFAULT_REGION = 'lon1'
+    DEFAULT_INITIAL_USER = 'civo'
+    DEFAULT_PUBLIC_IP = 'true'
+    DEFAULT_TEMPLATE = '811a8dfb-8202-49ad-b1ef-1e6320b20497'
+    option :size, default: DEFAULT_SIZE, banner: 'instance_size_code'
+    option :region, default: DEFAULT_REGION, banner: 'civo_region'
+    option :public_ip, default: DEFAULT_PUBLIC_IP, banner: 'true | false | from [instance_id]'
+    option :initial_user, default: DEFAULT_INITIAL_USER, banner: 'username', aliases: '--user'
     option :template, banner: 'template_id'
     option :snapshot, banner: 'snapshot_id'
     option :ssh_key, banner: 'ssh_key_id', aliases: '--ssh'
@@ -112,7 +117,7 @@ module CivoCLI
       end
 
       if !options[:template] && !options[:snapshot]
-        options[:template] = '811a8dfb-8202-49ad-b1ef-1e6320b20497'
+        options[:template] = DEFAULT_TEMPLATE
       end
 
 

--- a/lib/instance.rb
+++ b/lib/instance.rb
@@ -1,5 +1,11 @@
 module CivoCLI
   class Instance < Thor
+    DEFAULT_SIZE = 'g2.small'
+    DEFAULT_REGION = 'lon1'
+    DEFAULT_INITIAL_USER = 'civo'
+    DEFAULT_PUBLIC_IP = 'true'
+    DEFAULT_TEMPLATE = '811a8dfb-8202-49ad-b1ef-1e6320b20497'
+
     desc "list", "list all instances"
     def list
       CivoCLI::Config.set_api_auth
@@ -81,11 +87,6 @@ module CivoCLI
     map "get" => "show", "inspect" => "show"
 
     desc "create [HOSTNAME] [...]", "create a new instance with specified hostname and provided options"
-    DEFAULT_SIZE = 'g2.small'
-    DEFAULT_REGION = 'lon1'
-    DEFAULT_INITIAL_USER = 'civo'
-    DEFAULT_PUBLIC_IP = 'true'
-    DEFAULT_TEMPLATE = '811a8dfb-8202-49ad-b1ef-1e6320b20497'
     option :name, aliases: '--hostname', banner: 'hostname'
     option :size, default: DEFAULT_SIZE, banner: 'instance_size_code'
     option :region, default: DEFAULT_REGION, banner: 'civo_region'

--- a/lib/instance.rb
+++ b/lib/instance.rb
@@ -95,6 +95,7 @@ module CivoCLI
     option :ssh_key, banner: 'ssh_key_id', aliases: '--ssh'
     option :tags, banner: "'tag1 tag2 tag3...'"
     option :wait, type: :boolean
+    option :name, aliases: '--hostname', banner: 'hostname'
     long_desc <<-LONGDESC
       Create a new instance with hostname (randomly assigned if blank), instance size (default: g2.small),
       \x5template or snapshot ID (default: Ubuntu 18.04 template).
@@ -109,8 +110,16 @@ module CivoCLI
       \x5 --tags=<'tag1 tag2 tag3...'> - space-separated tag(s)
       \x5 --wait - wait for build to complete and show status. Off by default.
     LONGDESC
-    def create(hostname = CivoCLI::NameGenerator.create, *args)
+    def create(*args)
       CivoCLI::Config.set_api_auth
+
+      if !options[:name] && !args
+        hostname = CivoCLI::NameGenerator.create
+      elsif options[:name]
+        hostname = options[:name]
+      elsif !options[:name] && args
+        hostname = args.join('-')
+      end
       if options[:template] && options[:snapshot]
         puts "Please provide either template OR snapshot ID".colorize(:red)
         exit 1


### PR DESCRIPTION
Captures usage of `instance create HOSTNAME` as well as `instance create --name=HOSTNAME` and `intance create --hostname=HOSTNAME` so that they all behave the same.

If `--name` is present it takes precedence over any argument-provided name.