### PR TITLE
Implement check to see whether user multiple clusters

### DIFF
--- a/lib/finder.rb
+++ b/lib/finder.rb
@@ -21,6 +21,19 @@ class Finder
     end
   end
 
+  def self.check_for_single_cluster
+    result = []
+    Civo::Kubernetes.all.items.each do |element|
+      result << element
+    end
+    if result.count == 1
+      result[0]
+    else
+      puts 'Multiple possible Kubernetes clusters found. Please try again and specify the cluster with --cluster=NAME.'
+      exit 1
+    end
+  end
+
   def self.detect_app(name)
     result = []
     apps = Civo::Kubernetes.applications.items

--- a/lib/finder.rb
+++ b/lib/finder.rb
@@ -5,6 +5,14 @@ class Finder
       result << cluster
     end
 
+    id.blank?
+      if result.count == 1
+        return result[0]
+      elsif result.count > 1
+        puts 'Multiple possible Kubernetes clusters found. Please try again and specify the cluster with --cluster=NAME.'
+        exit 1
+      end
+      
     matched = result.detect { |cluster| cluster.name == id || cluster.id == id }
     return matched if matched
 
@@ -18,19 +26,6 @@ class Finder
       exit 1
     else
       result[0]
-    end
-  end
-
-  def self.check_for_single_cluster
-    result = []
-    Civo::Kubernetes.all.items.each do |element|
-      result << element
-    end
-    if result.count == 1
-      result[0]
-    else
-      puts 'Multiple possible Kubernetes clusters found. Please try again and specify the cluster with --cluster=NAME.'
-      exit 1
     end
   end
 

--- a/lib/finder.rb
+++ b/lib/finder.rb
@@ -5,13 +5,14 @@ class Finder
       result << cluster
     end
 
-    id.blank?
+    if id.blank?
       if result.count == 1
         return result[0]
       elsif result.count > 1
         puts 'Multiple possible Kubernetes clusters found. Please try again and specify the cluster with --cluster=NAME.'
         exit 1
       end
+    end
       
     matched = result.detect { |cluster| cluster.name == id || cluster.id == id }
     return matched if matched

--- a/lib/kubernetes_applications.rb
+++ b/lib/kubernetes_applications.rb
@@ -65,7 +65,7 @@ module CivoCLI
       CivoCLI::Config.set_api_auth
       name, plan = name.split(":")
       app = Finder.detect_app(name)
-      cluster = detect_cluster(options[:cluster])
+      cluster = Finder.detect_cluster(options[:cluster])
       plans = app.plans&.items
 
       if app && plans.present? && plan.blank?
@@ -94,14 +94,6 @@ module CivoCLI
     default_task :help
 
     private
-
-    def detect_cluster(cluster)
-      if cluster.present?
-        Finder.detect_cluster(cluster)
-      else
-        Finder.check_for_single_cluster
-      end
-    end
 
     def reject_user_access
       puts "Sorry, this functionality is currently in closed beta and not available to the public yet"

--- a/lib/kubernetes_applications.rb
+++ b/lib/kubernetes_applications.rb
@@ -65,7 +65,7 @@ module CivoCLI
       CivoCLI::Config.set_api_auth
       name, plan = name.split(":")
       app = Finder.detect_app(name)
-      cluster = Finder.detect_cluster(options[:cluster])
+      cluster = detect_cluster(options[:cluster])
       plans = app.plans&.items
 
       if app && plans.present? && plan.blank?
@@ -94,6 +94,14 @@ module CivoCLI
     default_task :help
 
     private
+
+    def detect_cluster(cluster)
+      if cluster.present?
+        Finder.detect_cluster(cluster)
+      else
+        Finder.check_for_single_cluster
+      end
+    end
 
     def reject_user_access
       puts "Sorry, this functionality is currently in closed beta and not available to the public yet"


### PR DESCRIPTION
If a user does not specify a cluster to install a kubernetes app to, checks
if the user has multiple clusters. If only one cluster is found, installs
specified app to that cluster. If multiple clusters found, lets user know.
Closes #38 when merged