### PR TITLE
Automatically set default apikeys

### DIFF
--- a/lib/apikey.rb
+++ b/lib/apikey.rb
@@ -33,6 +33,9 @@ module CivoCLI
         if keys.keys.include?(name)
           CivoCLI::Config.delete_apikey(name)
           puts "Removed the API Key #{name.colorize(:green)}"
+          if keys == 1
+            CivoCLI::Config.set_meta(:current_apikey, keys.keys.key)
+          end
         else
           puts "The API Key #{name.colorize(:red)} couldn't be found."
           exit 1

--- a/lib/apikey.rb
+++ b/lib/apikey.rb
@@ -20,6 +20,10 @@ module CivoCLI
     desc "add NAME KEY", "Add the API Key 'KEY' using a label of 'NAME'"
     def add(name, key)
       CivoCLI::Config.set_apikey(name, key)
+      keys = CivoCLI::Config.get_apikeys
+      if keys.length == 1
+        CivoCLI::Config.set_meta(:current_apikey, name)
+      end
       puts "Saved the API Key #{key.colorize(:green)} as #{name.colorize(:green)}"
     end
 


### PR DESCRIPTION
This is intended to fix https://github.com/civo/cli/issues/41 and also handle the inverse case: when a user deletes all but one key, the last remaining key should become the default. 

An additional behaviour is possible: when the user deletes the existing default, you could randomly assign a new default, but I think that could be confusing.

~~I've raised this as a draft PR, since it's unbuilt and untested so far. I'm also unsure about the `keys` data structure so `keys.keys.key` [here](https://github.com/civo/cli/pull/43/files#diff-957bdfaa1efe1267621da75187051ec9R37) might be wrong.~~

Feel free to comment. I've never used Ruby.