### PR TITLE
Windows Environment Changes for Kubernetes Config Save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the Civo CLI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.5] - 2019-10-08
+### Fixed
+- Behaviour of Kubernetes cluster configuration saving in Windows
+### Added
+- Help text for some common aliases when running `civo help`.
+
 ## [0.4.4] - 2019-09-30
 ### Added
 - Added DNS A record to kubernetes show command

--- a/lib/civo_cli.rb
+++ b/lib/civo_cli.rb
@@ -42,7 +42,7 @@ module CivoCLI
     subcommand "kubernetes", CivoCLI::Kubernetes
     map "k8s" => "kubernetes", "k3s" => "kubernetes"
 
-    desc "applications", "list and add marketplace applications to Kubernetes clusters. Alias: apps"
+    desc "applications", "list and add marketplace applications to Kubernetes clusters. Alias: apps, addons, marketplace, k8s-apps, k3s-apps"
     subcommand "applications", CivoCLI::KubernetesApplications
     map "apps" => "applications", "app" => "applications", "application" => "applications",
       "addon" => "applications", "addons" => "applications", "marketplace" => "applications",

--- a/lib/civo_cli.rb
+++ b/lib/civo_cli.rb
@@ -38,11 +38,11 @@ module CivoCLI
     subcommand "instance", CivoCLI::Instance
     map "instances" => "instance"
 
-    desc "kubernetes", "manage Kubernetes"
+    desc "kubernetes", "manage Kubernetes. Aliases: k8s, k3s"
     subcommand "kubernetes", CivoCLI::Kubernetes
     map "k8s" => "kubernetes", "k3s" => "kubernetes"
 
-    desc "applications", "list and add marketplace applications to Kubernetes clusters"
+    desc "applications", "list and add marketplace applications to Kubernetes clusters. Alias: apps"
     subcommand "applications", CivoCLI::KubernetesApplications
     map "apps" => "applications", "app" => "applications", "application" => "applications",
       "addon" => "applications", "addons" => "applications", "marketplace" => "applications",

--- a/lib/civo_cli/version.rb
+++ b/lib/civo_cli/version.rb
@@ -1,3 +1,3 @@
 module CivoCLI
-  VERSION = "0.4.4"
+  VERSION = "0.4.5"
 end

--- a/lib/kubernetes.rb
+++ b/lib/kubernetes.rb
@@ -270,7 +270,7 @@ module CivoCLI
           tempfile.close
           tempfile.unlink
         end
-      else 
+      else
         config_file_exists = File.exist?("#{ENV["HOME"]}/.kube/config")
         tempfile = Tempfile.new('import_kubeconfig')
         begin
@@ -278,9 +278,9 @@ module CivoCLI
           tempfile.size
           home = `echo %HOMEPATH%`.chomp
           if options[:switch]
-            ENV['KUBECONFIG']="#{tempfile.path};#{home}\\.kube\\config"
+            ENV['KUBECONFIG'] = "#{tempfile.path};#{home}\\.kube\\config"
           else
-            ENV['KUBECONFIG']="#{home}\\.kube\\config;#{tempfile.path}"
+            ENV['KUBECONFIG'] = "#{home}\\.kube\\config;#{tempfile.path}"
           end
           result = `kubectl config view --flatten`
           write_file(result)


### PR DESCRIPTION
These changes will allow Windows 10 users to save their KUBECONFIG and merge it into an existing .kube\config file if they have one.