### PR TITLE
Trap error when checking for current apikey if nil

### DIFF
--- a/lib/apikey.rb
+++ b/lib/apikey.rb
@@ -38,13 +38,11 @@ module CivoCLI
 
     desc "current [NAME]", "Either return the name of the current API key or set the current key to be the one with a label of 'NAME'"
     def current(name = nil)
-      if name.nil?
-        currentkey = CivoCLI::Config.get_current_apikey_name
-        if currentkey
+      currentkey = CivoCLI::Config.get_current_apikey_name
+      if name.nil? && currentkey
           puts "The current API Key is #{currentkey.colorize(:green)}"
-        else
+      elsif name.nil? && !currentkey
           puts "No current API Key set".colorize(:red)
-        end
       else
         keys = CivoCLI::Config.get_apikeys
         if keys.keys.include?(name)

--- a/lib/apikey.rb
+++ b/lib/apikey.rb
@@ -25,7 +25,7 @@ module CivoCLI
 
     desc "remove NAME", "Remove the API Key with a label of 'NAME'"
     def remove(name)
-       keys = CivoCLI::Config.get_apikeys
+      keys = CivoCLI::Config.get_apikeys
         if keys.keys.include?(name)
           CivoCLI::Config.delete_apikey(name)
           puts "Removed the API Key #{name.colorize(:green)}"
@@ -37,9 +37,14 @@ module CivoCLI
     map "delete" => "remove", "rm" => "remove"
 
     desc "current [NAME]", "Either return the name of the current API key or set the current key to be the one with a label of 'NAME'"
-    def current(name=nil)
+    def current(name = nil)
       if name.nil?
-        puts "The current API Key is #{CivoCLI::Config.get_current_apikey_name.colorize(:green)}"
+        currentkey = CivoCLI::Config.get_current_apikey_name
+        if currentkey
+          puts "The current API Key is #{currentkey.colorize(:green)}"
+        else
+          puts "No current API Key set".colorize(:red)
+        end
       else
         keys = CivoCLI::Config.get_apikeys
         if keys.keys.include?(name)

--- a/lib/apikey.rb
+++ b/lib/apikey.rb
@@ -30,6 +30,7 @@ module CivoCLI
         if keys.keys.include?(name)
           CivoCLI::Config.delete_apikey(name)
           puts "Removed the API Key #{name.colorize(:green)}"
+          current(nil)
         else
           puts "The API Key #{name.colorize(:red)} couldn't be found."
           exit 1

--- a/lib/apikey.rb
+++ b/lib/apikey.rb
@@ -21,6 +21,7 @@ module CivoCLI
     def add(name, key)
       CivoCLI::Config.set_apikey(name, key)
       puts "Saved the API Key #{key.colorize(:green)} as #{name.colorize(:green)}"
+      current(name)
     end
 
     desc "remove NAME", "Remove the API Key with a label of 'NAME'"


### PR DESCRIPTION
Checks whether a current key exists if the user calls `apikey current` and
returns a friendly error if nil
Closes #45