### PR TITLE
Docker Runtime Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Civo CLI is a tool to manage your [Civo.com](https://www.civo.com) account from 
 ## Table of contents
 - [Introduction](#introduction)
 - [Set-Up](#set-up) 
+- [Docker Usage](#docker-usage) 
 - [API Keys](#api-keys)
 - [Instances](#instances)
 - [Kubernetes clusters](#kubernetes-clusters)
@@ -45,6 +46,30 @@ To run the tool, simply run `civo` with your chosen options. You can find contex
 `civo instance help`,
 `civo instance help create`
 and so on. The main components of Civo CLI are outlined in the following sections.
+
+## Docker Usage
+The civo cli utilty can also run within a docker container, which avoids the need to maintain a Ruby environment on the main system.  To build the container
+
+```sh
+cd docker/
+docker build . -t civo:latest
+```
+
+To run, you generally will want to map the API key for presistence.
+
+```
+touch $HOME/.civo.json
+docker run -it --rm -v $HOME/.civo.json:/home/user/.civo.json civo
+```
+
+To make usage easier, an alias is recommended.  Here's an example how to set one, and using the docker image:
+```
+alias dcivo="docker run -it --rm -v $HOME/.civo.json:/home/user/.civo.json civo"
+dcivo sshkey list
+dcivo instance list
+dcivo instance create --size g2.xsmall
+dcivo k8s list
+```
 
 ## API Keys
 #### Introduction

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:slim-buster
+MAINTAINER Steve Miller <me@r15cookie.com>
+RUN gem install civo_cli
+RUN useradd -m user
+USER user
+ENTRYPOINT ["civo"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,4 @@
+# civo-cli in Docker
+
+Build a docker container embedded with the latest civo command.  Note that it does NOT yet build from source;
+it simply pulls the latest civo cli from RubyGems.  The docker that builds from source is a work in progress and available at

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,5 @@
 # civo-cli in Docker
 
 Build a docker container embedded with the latest civo command.  Note that it does NOT yet build from source;
-it simply pulls the latest civo cli from RubyGems.  The docker that builds from source is a work in progress and available at
+it simply pulls the latest civo cli from RubyGems.  Usage is in the main repo's README.  The docker that builds 
+from source is a work in progress and available at https://github.com/ssmiller25/cli/tree/dockerbuild


### PR DESCRIPTION
A quick docker runtime for the cli to isolate all the Ruby dependencies and builds into a container I can run on demand.  This version only installs the version of the CLI from RubyGems.