### PR TITLE
Re-adding Entrypoint

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,3 +3,4 @@ MAINTAINER Steve Miller <me@r15cookie.com>
 RUN gem install civo_cli
 RUN adduser -S user
 USER user
+ENTRYPOINT ["civo"]


### PR DESCRIPTION
The current docker configuration and alias instruction in the Readme results in just entering Ruby's irb interface.  I re-added the ENTRYPOINT statement to the docker file to launch the civo utility when the container is started.  An alternative to this would be to adjust the alias command to call `civo` within the container, but I think I prefer adjust the ENTRYPOINT as I presume most people don't thoroughly go through documentation, and with ENTRYPOINT set you'll at least get the civo help contents versus being stuck at an irb prompt.