### PR TITLE
Kube config path fix for windows.

### DIFF
--- a/lib/kubernetes.rb
+++ b/lib/kubernetes.rb
@@ -336,11 +336,10 @@ module CivoCLI
         tempfile.write(cluster.kubeconfig)
         tempfile.size
         if windows?
-          home = `echo %HOMEPATH%`.chomp
           if options[:switch]
-            ENV['KUBECONFIG'] = "#{tempfile.path};#{home}\\.kube\\config"
+            ENV['KUBECONFIG'] = "#{tempfile.path};#{Dir.home}\\.kube\\config"
           else
-            ENV['KUBECONFIG'] = "#{home}\\.kube\\config;#{tempfile.path}"
+            ENV['KUBECONFIG'] = "#{Dir.home}\\.kube\\config;#{tempfile.path}"
           end
           result = `kubectl config view --flatten`
         else


### PR DESCRIPTION
This PR should fix #58 which seems to be windows specific.

The `echo %HOMEPATH%.chomp` has been changed to instead just use the platform independent `Dir.home` which should return a more correct path than the earlier version.  

Tested locally on windows 10 pro with both Cmder (conemu) and with powershell with great success!

----

It might also be possible to just use `ENV['HOME']` seeing it is successfully used further down in the file:

```
    def write_file(result)
      Dir.mkdir("#{ENV['HOME']}/.kube/") unless Dir.exist?("#{ENV["HOME"]}/.kube/")
      File.write("#{ENV['HOME']}/.kube/config", result)
    end
```

But I'm not sure it is possible to assure that the `HOME` env variable is always present on windows systems.  
I did not change the write_file method though, seeing it seems to work for now and could easily be changed if anyone encounters issues with it at a later point.